### PR TITLE
Show rewards generated for ended programs

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -18,7 +18,12 @@ export default function Routes(): JSX.Element {
     <Switch>
       <Route exact path="/" component={Home} />
       {knownPools.map(({ path, name }) => (
-        <Route exact path={path} render={() => <Pool name={name} />} />
+        <Route
+          exact
+          path={path}
+          render={() => <Pool name={name} />}
+          key={name}
+        />
       ))}
       <Redirect to="/" />
     </Switch>

--- a/src/components/Pool/PoolControls/Claim.tsx
+++ b/src/components/Pool/PoolControls/Claim.tsx
@@ -10,11 +10,11 @@ import TotalRewardsCard from './TotalRewardsCard'
 
 function Claim(): JSX.Element {
   const { contractGroup } = usePoolInfo()
-  const { rewardsBalanceInfo } = usePoolBalance()
+  const {
+    rewardsBalanceInfo: [rewardsBalance],
+  } = usePoolBalance()
   const { showAccount } = useAccountModule()
   const handleClaim = useClaimRewards(contractGroup)
-
-  const [rewardsBalance] = rewardsBalanceInfo
 
   const validationStatus = useMemo((): ValidationStatus => {
     if (!rewardsBalance) {

--- a/src/components/Pool/PoolControls/Claim.tsx
+++ b/src/components/Pool/PoolControls/Claim.tsx
@@ -1,30 +1,20 @@
 import React, { useCallback, useMemo } from 'react'
 // @ts-ignore
-import TokenAmount from 'token-amount'
 import { useClaimRewards } from '../../../hooks/useContract'
 import { useAccountModule } from '../../Account/AccountModuleProvider'
-import AmountCard from '../../AmountCard/AmountCard'
 import { usePoolBalance } from '../PoolBalanceProvider'
 import { usePoolInfo } from '../PoolInfoProvider'
 import { ValidationStatus } from '../types'
 import ControlButton from './ControlButton'
+import TotalRewardsCard from './TotalRewardsCard'
 
 function Claim(): JSX.Element {
-  const { rewardToken, contractGroup } = usePoolInfo()
-  const { rewardsBalanceInfo, formattedDigits } = usePoolBalance()
+  const { contractGroup } = usePoolInfo()
+  const { rewardsBalanceInfo } = usePoolBalance()
   const { showAccount } = useAccountModule()
   const handleClaim = useClaimRewards(contractGroup)
 
-  const [rewardsBalance, rewardsBalanceStatus] = rewardsBalanceInfo
-
-  const formattedRewardsBalance = useMemo(
-    (): string | null =>
-      rewardsBalance &&
-      new TokenAmount(rewardsBalance, rewardToken.decimals).format({
-        digits: formattedDigits,
-      }),
-    [rewardsBalance, rewardToken.decimals, formattedDigits]
-  )
+  const [rewardsBalance] = rewardsBalanceInfo
 
   const validationStatus = useMemo((): ValidationStatus => {
     if (!rewardsBalance) {
@@ -55,16 +45,7 @@ function Claim(): JSX.Element {
 
   return (
     <form onSubmit={handleSubmit}>
-      <AmountCard
-        label="Total rewards generated"
-        tokenGraphic={rewardToken.graphic}
-        suffix={rewardToken.symbol}
-        value={formattedRewardsBalance ? formattedRewardsBalance : '0'}
-        loading={rewardsBalanceStatus === 'loading'}
-        css={`
-          margin-top: 10px;
-        `}
-      />
+      <TotalRewardsCard />
       <ControlButton
         status={validationStatus}
         labels={{

--- a/src/components/Pool/PoolControls/Stake.tsx
+++ b/src/components/Pool/PoolControls/Stake.tsx
@@ -23,7 +23,7 @@ function Stake(): JSX.Element {
   } = usePoolBalance()
   const stake = useStake(contractGroup)
 
-  const rewardsCardLoading = useMemo(
+  const estRewardsLoading = useMemo(
     () =>
       [stakedBalanceStatus, poolTotalSupplyStatus, rewardRateStatus].includes(
         'loading'
@@ -136,7 +136,7 @@ function Stake(): JSX.Element {
         value={formattedRewards}
         tokenGraphic={rewardToken.graphic}
         suffix={`${rewardToken.symbol} / week`}
-        loading={rewardsCardLoading}
+        loading={estRewardsLoading}
       />
       <ControlButton
         status={validationStatus}

--- a/src/components/Pool/PoolControls/Stake.tsx
+++ b/src/components/Pool/PoolControls/Stake.tsx
@@ -17,11 +17,19 @@ function Stake(): JSX.Element {
   const {
     accountBalanceInfo: [accountBalance],
     stakedBalanceInfo: [stakedBalance, stakedBalanceStatus],
-    totalSupplyInfo: [poolTotalSupply],
-    rewardRateInfo: [rewardRate],
+    totalSupplyInfo: [poolTotalSupply, poolTotalSupplyStatus],
+    rewardRateInfo: [rewardRate, rewardRateStatus],
     formattedDigits,
   } = usePoolBalance()
   const stake = useStake(contractGroup)
+
+  const rewardsCardLoading = useMemo(
+    () =>
+      [stakedBalanceStatus, poolTotalSupplyStatus, rewardRateStatus].includes(
+        'loading'
+      ),
+    [stakedBalanceStatus, poolTotalSupplyStatus, rewardRateStatus]
+  )
 
   const {
     maxAmount,
@@ -128,6 +136,7 @@ function Stake(): JSX.Element {
         value={formattedRewards}
         tokenGraphic={rewardToken.graphic}
         suffix={`${rewardToken.symbol} / week`}
+        loading={rewardsCardLoading}
       />
       <ControlButton
         status={validationStatus}

--- a/src/components/Pool/PoolControls/TotalRewardsCard.tsx
+++ b/src/components/Pool/PoolControls/TotalRewardsCard.tsx
@@ -1,0 +1,38 @@
+import React, { useMemo } from 'react'
+// @ts-ignore
+import TokenAmount from 'token-amount'
+import AmountCard from '../../AmountCard/AmountCard'
+import { usePoolBalance } from '../PoolBalanceProvider'
+import { usePoolInfo } from '../PoolInfoProvider'
+
+function TotalRewardsCard(): JSX.Element {
+  const { rewardToken } = usePoolInfo()
+  const { rewardsBalanceInfo, formattedDigits } = usePoolBalance()
+
+  const [rewardsBalance, rewardsBalanceStatus] = rewardsBalanceInfo
+
+  const formattedRewardsBalance = useMemo(
+    (): string =>
+      rewardsBalance
+        ? new TokenAmount(rewardsBalance, rewardToken.decimals).format({
+            digits: formattedDigits,
+          })
+        : '0',
+    [rewardsBalance, rewardToken.decimals, formattedDigits]
+  )
+
+  return (
+    <AmountCard
+      label="Total rewards generated"
+      tokenGraphic={rewardToken.graphic}
+      suffix={rewardToken.symbol}
+      value={formattedRewardsBalance}
+      loading={rewardsBalanceStatus === 'loading'}
+      css={`
+        margin-top: 10px;
+      `}
+    />
+  )
+}
+
+export default TotalRewardsCard

--- a/src/components/Pool/PoolControls/Withdraw.tsx
+++ b/src/components/Pool/PoolControls/Withdraw.tsx
@@ -24,6 +24,7 @@ function Withdraw({ exitAllBalance }: WithdrawProps): JSX.Element {
   const {
     stakedBalanceInfo: [stakedBalance, stakedBalanceStatus],
     formattedDigits,
+    rewardsBalanceInfo: [rewardsBalance],
   } = usePoolBalance()
   const { showAccount } = useAccountModule()
   const withdraw = useWithdraw(contractGroup)
@@ -44,16 +45,16 @@ function Withdraw({ exitAllBalance }: WithdrawProps): JSX.Element {
 
   // TODO: Fix this hack
   const exitAllValidationStatus = useMemo(() => {
-    if (!stakedBalance) {
+    if (!stakedBalance || !rewardsBalance) {
       return 'notConnected'
     }
 
-    if (stakedBalance.isZero()) {
+    if (stakedBalance.isZero() && rewardsBalance.isZero()) {
       return 'insufficientBalance'
     }
 
     return 'valid'
-  }, [stakedBalance])
+  }, [stakedBalance, rewardsBalance])
 
   const filteredValidationStatus = exitAllBalance
     ? exitAllValidationStatus

--- a/src/components/Pool/PoolControls/Withdraw.tsx
+++ b/src/components/Pool/PoolControls/Withdraw.tsx
@@ -11,6 +11,7 @@ import AmountInput from '../../AmountInput/AmountInput'
 import { usePoolBalance } from '../PoolBalanceProvider'
 import { usePoolInfo } from '../PoolInfoProvider'
 import ControlButton from './ControlButton'
+import TotalRewardsCard from './TotalRewardsCard'
 import useInputValidation from './useInputValidation'
 
 type WithdrawProps = {
@@ -127,12 +128,19 @@ function Withdraw({ exitAllBalance }: WithdrawProps): JSX.Element {
       )}
 
       <AmountCard
-        label={`Amount available to withdraw`}
+        label={
+          exitAllBalance
+            ? 'Total amount staked'
+            : 'Amount available to withdraw'
+        }
         tokenGraphic={stakeToken.graphic}
         suffix={stakeToken.symbol}
         value={formattedStakedBalance ? formattedStakedBalance : '0'}
         loading={stakedBalanceStatus === 'loading'}
       />
+
+      {exitAllBalance && <TotalRewardsCard />}
+
       <ControlButton
         status={filteredValidationStatus}
         labels={{
@@ -141,7 +149,7 @@ function Withdraw({ exitAllBalance }: WithdrawProps): JSX.Element {
             ? 'You have no funds to withdraw'
             : 'Insufficient stake balance',
           noAmount: 'Enter an amount',
-          valid: 'Withdraw',
+          valid: exitAllBalance ? 'Withdraw all' : 'Withdraw',
           loading: 'Loading…',
         }}
       />


### PR DESCRIPTION
Previously we were only showing the total amount staked excluding rewards generated after a program was completed.

This PR adds that information and fixes a couple of other small visual quirks.

![image](https://user-images.githubusercontent.com/11708259/98571122-1cedd500-22ac-11eb-8b6b-ecf5e2354978.png)
